### PR TITLE
accessd: Turn off debug mode by default

### DIFF
--- a/audit/afs-client-accessd
+++ b/audit/afs-client-accessd
@@ -450,7 +450,7 @@ use DBD::SQLite;
 #
 
 # set to 1 to enable debug logging
-use constant DEBUG => 1;
+use constant DEBUG => 0;
 
 # check for db rotation about once every ALARM_INTERVAL seconds
 use constant ALARM_INTERVAL => 600; # 10 minutes


### PR DESCRIPTION
Commit 31610e70e7f8e0768c26c592e4645b9b60738f65 accidentally turned on
the DEBUG constant. Turn it back off, so we don't spew debug messages
by default.

Change-Id: Ib803ca46732968d601b4b1d18416924cbbd7ff75
